### PR TITLE
docs: 文档补充

### DIFF
--- a/docs/接口文档.md
+++ b/docs/接口文档.md
@@ -12,7 +12,7 @@
 ```typescript
 // POST /auth/login 
 interface Request {
-  username: string;
+  id: string;
   password: string;
   remember: boolean;
 }
@@ -57,6 +57,8 @@ interface Response {
 // POST /employee/create
 interface CreateRequest {
   type: 'salary' | 'commission';
+  origin_id: string; // 员工名字的拼音，后端自动检测拼音是否重复，如有重复要自动加上数字
+  name: string; // 员工名字
   address: string;
   socsec_id: string;
   tax_rate: number;
@@ -69,7 +71,7 @@ interface CreateRequest {
 }
 
 interface CreateResponse extends CreateRequest {
-  id: string;
+  id: string; // 新的 id，一般是员工拼音 + 数字：如果没有拼音就不用数字
   jwt: string;
 }
 

--- a/docs/数据表设计.md
+++ b/docs/数据表设计.md
@@ -9,7 +9,7 @@ interface Auth {
   role: 'employee' | 'commission' | 'payroll';
 }
 
-// JWT 携带的信息
+// JWT 携带的信息，作为 JWT 携带的信息而不用作为数据表
 interface JWT {
   id: string;
   role: string;


### PR DESCRIPTION
# Change Log

- 登录请求「用户名」改为「id」
- 创建员工时多携带两个参数：`origin_id`代表拼音，`name`代表员工名称，返回的时候这个拼音为了不重复需要后端自动加上拼音
- `JWT`补充说明：不需要作为数据表，只说明需要携带的信息