### PR TITLE
docs: 文档补充

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -176,13 +176,13 @@ interface GetAvailableRequest {
 // POST /timecard/update
 interface UpdateRequest {
   jwt: string;
+  id: string;
   data: {
-    id: string;
     projectName: string;
-    startTime: string;
-    endTime: string;
     duration: number;
   }[];
+  startTime: string;
+  endTime: string;
 }
 
 interface UpdateResponse {}

--- a/docs/API.md
+++ b/docs/API.md
@@ -181,8 +181,6 @@ interface UpdateRequest {
     projectName: string;
     duration: number;
   }[];
-  startTime: string;
-  endTime: string;
 }
 
 interface UpdateResponse {}

--- a/docs/API.md
+++ b/docs/API.md
@@ -111,6 +111,7 @@ interface DeleteResponse {}
 ```typescript
 // POST /purchase/create
 interface CreateRequest {
+  jwt: string;
   phone: string;
   address: string;
   productName: string;
@@ -120,7 +121,18 @@ interface CreateRequest {
 
 interface CreateResponse {
   id: string;
-  employeeId: string;
+}
+
+// GET /purchase/gets 
+interface GetsRequest {
+  jwt: string;
+  pageIndex: number;
+  pageSize: number;
+}
+
+interface GetsResponse {
+  total: number; // 属于请求用户的所有采购订单的总数
+  data: PurchaseOrder[]
 }
 
 // GET /purchase/get 

--- a/docs/API.md
+++ b/docs/API.md
@@ -46,7 +46,7 @@ interface Response {
 interface Request {
   type: 'duration' | 'proj_duration' | 'vacation' | 'salary';
   jwt: string;
-  projectName?: string;
+  timeCardId?: string;
   startTime: string;
   endTime: string;
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -160,7 +160,8 @@ interface GetRequest {
 }
 
 interface GetResponse {
-  data: Timecard[];
+  total: number; // 用户所持有的考勤卡的总数
+  data: Timecard[]; // 用户所持有的考勤卡的分页数据
 }
 
 // GET /timecard/available

--- a/docs/数据表设计.md
+++ b/docs/数据表设计.md
@@ -54,10 +54,16 @@ interface Timecard {
   id: string;
   employee_id: string;
   project_name: string;
+  duration: number;
   is_save: boolean;
   start_time: string;
   end_time: string;
-  duration: number;
+}
+
+interface TimecardProject { // 考勤卡上面的各种项目，一对多，一是考勤卡，多是项目
+  id: string;
+  project_name: string;
+  duration: string;
 }
 ```
 

--- a/docs/数据表设计.md
+++ b/docs/数据表设计.md
@@ -98,8 +98,10 @@ interface ProjectDurationReport {
   employee_name: string;
   start_time: string;
   end_time: string;
-  project_name: string;
-  duration: number;
+  data: {
+    project_name: string;
+    duration: number;
+  }[];
 }
 
 interface VacationReport {


### PR DESCRIPTION
# Change Log

- 用户创建报表时，若选择工程总时间，应用`timeCardId`来获取
- 用户提交考勤卡的时候，`projectName + duration`应分开来作为数组
- 一个考勤卡会对应多个项目，因此加上了`TimecardProject`，`TimecardProject`中的 `id` 作为连接`Timecard`主键的外键
- 更新考勤卡中的`Request`参数改正
- 获取某个用户所归属的考勤卡需要带上`total`
- `ProjectDuration`字段改变，应获取`TimeCard`对应的所有`ProjectName` + `duration` 的数组
- 增加接口：获取属于请求的用户的一些采购订单，`GET /purchase/gets`
- 更改接口：创建采购订单不再返回`employee_id`
- 创建员工的时候，`originId`改为`id`